### PR TITLE
Fix infinite loop bug in parseAtom.

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function sexp(source, opts) {
 
     function parseAtom() {
         var start = ix++;
-        while (ATOM.test(source[ix]))
+        while (ix < source.length && ATOM.test(source[ix]))
             ix++;
         var atom = source.substring(start, ix);
         if (NUMBER.test(atom)) {


### PR DESCRIPTION
Some inputs, e.g. '(+', cause parseAtom to hang forever. This change prevents that.

Some context: I'm calling this parser from a text editor's onchange event, so it needs to be able to handle parse errors graciously. Before this change it causes the page to freeze on some ill-formed inputs.